### PR TITLE
remove two migration pages in apollo server

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,8 +27,6 @@ sidebar_categories:
     - apollo-server/setup
     - apollo-server/requests
     - apollo-server/graphiql
-    - apollo-server/migration-hapi
-    - apollo-server/migration
   Subscriptions:
     - graphql-subscriptions/index
     - graphql-subscriptions/subscriptions-to-schema


### PR DESCRIPTION
close #13 and close #14
在 apollo-server 菜单中移除 Migrating to v0.2(migration.md) 和 Migrating to v0.3(migartion-hapi.md) 两个页面
由于现在 apollo-server 版本已经升到 v1.1.2，目测不会有人还需要看升级到 0.2 和 0.3 的中文文档